### PR TITLE
Remove ROOT and WORKDIR instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,4 @@ RUN Rscript -e 'remotes::install_deps("/bound", dependencies = TRUE)'
 
 COPY . /bound
 
-WORKDIR /bound
-
-CMD ["./bin/run-pacta"]
+CMD ["/bound/bin/run-pacta", "/bound"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM rocker/r-ver:latest
 
-USER root
-
 RUN Rscript -e 'install.packages("remotes")'
 
 COPY DESCRIPTION /bound/DESCRIPTION

--- a/bin/run-pacta
+++ b/bin/run-pacta
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
-cp -r ../input/*.yml ./working_dir/10_Parameter_File
-cp -r ../input/*.csv ./working_dir/20_Raw_Inputs
 
-Rscript --vanilla -e "source('R/run_pacta.R'); run_pacta()"
-cp -r ./working_dir ../output
+here=$(pwd)
+pacta=${1:-$(pwd)}
+parent=$(dirname $pacta)
+
+cp -r "$parent"/input/*.yml "$pacta"/working_dir/10_Parameter_File
+cp -r "$parent"/input/*.csv "$pacta"/working_dir/20_Raw_Inputs
+
+Rscript --vanilla -e "setwd('""$pacta""'); source('R/run_pacta.R'); run_pacta()"
+cp -r "$pacta"/working_dir "$parent"/output


### PR DESCRIPTION
Closes #15

Here I refactor to remove the ROOT and WORKDIR instructions.

@jdhoffa please try this PR locally. I think you said that removing `ROOT` broke your tool but I can't reproduce that.

To remove `WORKDIR` I added an argument to `./bin/run-pacta` so we can specify where `pactaCore` lives inside the container. This could be avoided if `run_pacta()` could find pactaCore/ in a system. We could do that with e.g. the `.pacta` marker I use in the `pacta-cli` to find siblings.