### PR TITLE
Snapshot-test for bash tree

### DIFF
--- a/bin/test-pacta
+++ b/bin/test-pacta
@@ -28,20 +28,14 @@ tree ../input ../output > "$actual"
 cat "$actual"
 echo
 
-yellow "Diff with snapshot"
 difference=$(diff "$actual" tests/bash/snapshots/results-tree.txt)
-if [ $difference -eq "" ];
+if [[ $difference != "" ]]
 then
-  echo "Good to go"
-fi
-
-if [[ $difference -eq "" ]]
-then
-  green "Good to go."
-else
   red "The output tree is NOT as expected:"
+  red $difference
+else
+  echo "Good to go."
+  echo
 fi
-echo $difference
-echo
 
 yellow "Done"

--- a/bin/test-pacta
+++ b/bin/test-pacta
@@ -1,13 +1,47 @@
 #!/usr/bin/env bash
 
+red () {
+    printf "\033[31m${1}\033[0m\n"
+}
+
+yellow () {
+    printf "\033[33m${1}\033[0m\n"
+}
+
+green () {
+    printf "\033[32m${1}\033[0m\n"
+}
+
 rm -rf ../output ../input
 bash bin/setup-io
 
-echo "IO tree at the start"
+yellow "IO tree at the start"
 tree ../input ../output
 echo
 docker-compose up --build
 echo
 
-echo "IO tree at the end"
-tree ../input ../output/working_dir/40_Results
+yellow "IO tree at the end"
+actual=$(tempfile)
+tree ../input ../output > "$actual"
+
+cat "$actual"
+echo
+
+yellow "Diff with snapshot"
+difference=$(diff "$actual" tests/bash/snapshots/results-tree.txt)
+if [ $difference -eq "" ];
+then
+  echo "Good to go"
+fi
+
+if [[ $difference -eq "" ]]
+then
+  green "Good to go."
+else
+  red "The output tree is NOT as expected:"
+fi
+echo $difference
+echo
+
+yellow "Done"

--- a/bin/test-pacta
+++ b/bin/test-pacta
@@ -12,16 +12,20 @@ green () {
     printf "\033[32m${1}\033[0m\n"
 }
 
+yellow "* Setting up fresh test input/ and output/ directories"
 rm -rf ../output ../input
 bash bin/setup-io
 
-yellow "IO tree at the start"
+yellow "* Ensuring working_dir/ has the expected file-system structure"
+bash bin/mkdir-working_dir
+
+yellow "* IO tree at the start"
 tree ../input ../output
 echo
 docker-compose up --build
 echo
 
-yellow "IO tree at the end"
+yellow "* IO tree at the end"
 actual=$(tempfile)
 tree ../input ../output > "$actual"
 
@@ -31,11 +35,10 @@ echo
 difference=$(diff "$actual" tests/bash/snapshots/results-tree.txt)
 if [[ $difference != "" ]]
 then
-  red "The output tree is NOT as expected:"
+  red "* The output tree is NOT as expected. Difference:"
   red $difference
 else
-  echo "Good to go."
-  echo
+  green "* Good to go."
 fi
 
-yellow "Done"
+yellow "* Done"

--- a/tests/bash/snapshots/results-tree.txt
+++ b/tests/bash/snapshots/results-tree.txt
@@ -1,0 +1,39 @@
+../input
+├── TestPortfolio_Input.csv
+└── TestPortfolio_Input_PortfolioParameters.yml
+../output
+└── working_dir
+    ├── 00_Log_Files
+    │   └── TestPortfolio_Input
+    ├── 10_Parameter_File
+    │   └── TestPortfolio_Input_PortfolioParameters.yml
+    ├── 20_Raw_Inputs
+    │   └── TestPortfolio_Input.csv
+    ├── 30_Processed_Inputs
+    │   └── TestPortfolio_Input
+    │       ├── audit_file.csv
+    │       ├── audit_file.rda
+    │       ├── bonds_portfolio.rda
+    │       ├── coveragegraph.json
+    │       ├── coveragegraphlegend.json
+    │       ├── coveragetextvar.json
+    │       ├── emissions.rda
+    │       ├── equity_portfolio.rda
+    │       ├── fund_coverage_summary.rda
+    │       ├── invalidsecurities.csv
+    │       ├── invalidsecurities.json
+    │       ├── overview_portfolio.rda
+    │       ├── portfolio_weights.json
+    │       └── total_portfolio.rda
+    ├── 40_Results
+    │   └── TestPortfolio_Input
+    │       ├── Bonds_results_company.rda
+    │       ├── Bonds_results_map.rda
+    │       ├── Bonds_results_portfolio.rda
+    │       ├── Equity_results_company.rda
+    │       ├── Equity_results_map.rda
+    │       └── Equity_results_portfolio.rda
+    └── 50_Outputs
+        └── TestPortfolio_Input
+
+11 directories, 24 files


### PR DESCRIPTION
This PR extends bin/test-pacta to add a basic snapshot test of the tree of the output. It does not meet the requirements of [AB#1187](https://dev.azure.com/2DegreesInvesting/a5201d6a-87ad-4acf-b862-9cba0e1ae681/_workitems/edit/1187) but has a similar spirit and can help until we have a more complete snapshot.

For redability and fun I added colours to the output:

* red for bad news
* yellow for neutral news
* green for good news

<img src=https://i.imgur.com/EKjzbxs.png width=400>

...

<img src=https://i.imgur.com/6m9U2TO.png width=400>