### PR TITLE
Snapshot result datasets in full

### DIFF
--- a/tests/testthat/test-run_pacta.R
+++ b/tests/testthat/test-run_pacta.R
@@ -9,6 +9,10 @@ test_that("creates the expected results", {
   files <- dir_ls(results_path(parent), type = "file", recurse = TRUE)
   datasets <- lapply(files, readRDS)
   names(datasets) <- path_ext_remove(path_file(names(datasets)))
+
+  classes <- lapply(datasets, function(x) unlist(lapply(x, class)))
+  expect_snapshot(classes)
+
   datasets[] <- lapply(datasets, as.data.frame)
   expect_snapshot(datasets)
 })

--- a/tests/testthat/test-run_pacta.R
+++ b/tests/testthat/test-run_pacta.R
@@ -9,7 +9,7 @@ test_that("creates the expected results", {
   files <- dir_ls(results_path(parent), type = "file", recurse = TRUE)
   datasets <- lapply(files, readRDS)
   names(datasets) <- path_ext_remove(path_file(names(datasets)))
-
+  datasets[] <- lapply(datasets, as.data.frame)
   expect_snapshot(datasets)
 })
 


### PR DESCRIPTION
Closes #55

- Results snapshots now show datasets in full
- Snapshot the typeof columns

For details see commit messages.
