### PR TITLE
Allow empty output directory

### DIFF
--- a/R/run_pacta.R
+++ b/R/run_pacta.R
@@ -36,7 +36,7 @@ run_pacta_impl <- function(env = ".env",
   input <- path_env("PACTA_INPUT", env)
   output <- path_env("PACTA_OUTPUT", env)
   abort_if_missing_inputs(input)
-  abort_if_not_empty_dir(results_path(fs::path_dir(output)))
+  abort_if_not_empty_dir(results_path(path_dir(output)))
 
   data <- path_env("PACTA_DATA", env)
   # r"()" was introduced in R 4.0.0

--- a/R/run_pacta.R
+++ b/R/run_pacta.R
@@ -35,6 +35,7 @@ run_pacta_impl <- function(env = ".env",
                            code = expression(system(docker_run))) {
   input <- path_env("PACTA_INPUT", env)
   output <- path_env("PACTA_OUTPUT", env)
+  abort_if_missing_inputs(input)
   abort_if_not_empty_dir(results_path(fs::path_dir(output)))
 
   data <- path_env("PACTA_DATA", env)

--- a/R/run_pacta.R
+++ b/R/run_pacta.R
@@ -26,9 +26,16 @@
 #'   })
 #' }
 run_pacta <- function(env = ".env") {
+  run_pacta_impl(env)
+  invisible(env)
+}
+
+# `code` allows injecting test code
+run_pacta_impl <- function(env = ".env",
+                           code = expression(system(docker_run))) {
   input <- path_env("PACTA_INPUT", env)
   output <- path_env("PACTA_OUTPUT", env)
-  abort_if_dir_exists(results_path(fs::path_dir(output)))
+  abort_if_not_empty_dir(results_path(fs::path_dir(output)))
 
   data <- path_env("PACTA_DATA", env)
   # r"()" was introduced in R 4.0.0
@@ -50,7 +57,8 @@ run_pacta <- function(env = ".env") {
     "docker run --rm -v %s:/input -v %s:/output -v %s:/pacta-data:ro %s %s",
     input, output, data, image_tag, command_arg
   )
-  system(docker_run)
+
+  eval(code)
 
   invisible(env)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -42,6 +42,16 @@ context_path <- function(..., mustWork = FALSE) {
 
 results_path <- function(parent, ..., regexp = portfolio_pattern()) {
   portfolios <- portfolio_names(path(parent, "input"), regexp = regexp)
+  none <- identical(portfolios, character(0))
+  if (none) {
+    stop(
+      "Can't find a porfolio file matching '", regexp, "' insude input/:\n",
+      path(parent, "input"), "\n",
+      "Is your setup as in https://github.com/2DegreesInvesting/pactaCore?",
+      call. = FALSE
+    )
+  }
+
   path(parent, "output", "working_dir", "40_Results", portfolios, ...)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -42,20 +42,7 @@ context_path <- function(..., mustWork = FALSE) {
 
 results_path <- function(parent, ..., regexp = portfolio_pattern()) {
   portfolios <- portfolio_names(path(parent, "input"), regexp = regexp)
-  abort_if_missing_portfolio(portfolios)
-
   path(parent, "output", "working_dir", "40_Results", portfolios, ...)
-}
-
-abort_if_missing_portfolio <- function(portfolios) {
-  none <- identical(portfolios, character(0))
-  if (none) {
-    stop(
-      "The input/ directory must have a porfolio file but it doesn't.\n",
-      "Is your setup as per https://github.com/2DegreesInvesting/pactaCore?",
-      call. = FALSE
-    )
-  }
 }
 
 working_dir_paths <- function(portfolio_name = example_input_name()) {
@@ -201,4 +188,22 @@ is_empty_dir <- function(path) {
 
 expect_no_error <- function(object, ...) {
   testthat::expect_error(object, regexp = NA, ...)
+}
+
+abort_if_missing_inputs <- function(path) {
+  portfolio <- dir_ls(path, regexp = "Input[.]csv")
+  parameter <- dir_ls(path, regexp = "Input_PortfolioParameters[.]yml")
+  missing_portfolio <- identical(unclass(unname(portfolio)), character(0))
+  missing_parameter <- identical(unclass(unname(parameter)), character(0))
+  if (missing_portfolio || missing_parameter) {
+    stop(
+      "The input/ directory must have at least one pair of files:\n",
+      "* A porfolio file named <pair-name>_Input.csv.\n",
+      "* A parameter file named <pair-name>_Input_PortfolioParameters.yml.\n",
+      "Is your setup as per https://github.com/2DegreesInvesting/pactaCore?",
+      call. = FALSE
+    )
+  }
+
+  invisible(path)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -42,17 +42,20 @@ context_path <- function(..., mustWork = FALSE) {
 
 results_path <- function(parent, ..., regexp = portfolio_pattern()) {
   portfolios <- portfolio_names(path(parent, "input"), regexp = regexp)
+  abort_if_missing_portfolio(portfolios)
+
+  path(parent, "output", "working_dir", "40_Results", portfolios, ...)
+}
+
+abort_if_missing_portfolio <- function(portfolios) {
   none <- identical(portfolios, character(0))
   if (none) {
     stop(
-      "Can't find a porfolio file matching '", regexp, "' insude input/:\n",
-      path(parent, "input"), "\n",
-      "Is your setup as in https://github.com/2DegreesInvesting/pactaCore?",
+      "The input/ directory must have a porfolio file but it doesn't.\n",
+      "Is your setup as per https://github.com/2DegreesInvesting/pactaCore?",
       call. = FALSE
     )
   }
-
-  path(parent, "output", "working_dir", "40_Results", portfolios, ...)
 }
 
 working_dir_paths <- function(portfolio_name = example_input_name()) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,14 +27,6 @@ create_working_dir <- function(dir = tempdir()) {
   invisible(dir)
 }
 
-abort_if_dir_exists <- function(dir) {
-  if (dir_exists(dir)) {
-    stop("This directory must not exist but it does:\n", dir, call. = FALSE)
-  }
-
-  invisible(dir)
-}
-
 portfolio_names <- function(dir, regexp) {
   csv <- fs::dir_ls(dir, regexp = regexp)
   fs::path_ext_remove(fs::path_file(csv))
@@ -177,4 +169,23 @@ update_pacta_legacy <- function(file = context_path("pacta_legacy.R")) {
   writeLines(code, file)
 
   invisible(file)
+}
+
+abort_if_not_empty_dir <- function(path) {
+  if (dir_exists(path) && !is_empty_dir(path)) {
+    stop(
+      "This directory must be empty but isn't:\n",
+      path,
+      call. = FALSE
+    )
+  }
+  invisible(path)
+}
+
+is_empty_dir <- function(path) {
+  identical(unname(unclass(dir_ls(path))), character(0))
+}
+
+expect_no_error <- function(object, ...) {
+  testthat::expect_error(object, regexp = NA, ...)
 }

--- a/tests/testthat/_snaps/run_pacta.md
+++ b/tests/testthat/_snaps/run_pacta.md
@@ -1,5 +1,14 @@
 # without portfolio errors gracefully
 
-    The input/ directory must have a porfolio file but it doesn't.
+    The input/ directory must have at least one pair of files:
+    * A porfolio file named <pair-name>_Input.csv.
+    * A parameter file named <pair-name>_Input_PortfolioParameters.yml.
+    Is your setup as per https://github.com/2DegreesInvesting/pactaCore?
+
+# without a parameter file errors gracefully
+
+    The input/ directory must have at least one pair of files:
+    * A porfolio file named <pair-name>_Input.csv.
+    * A parameter file named <pair-name>_Input_PortfolioParameters.yml.
     Is your setup as per https://github.com/2DegreesInvesting/pactaCore?
 

--- a/tests/testthat/test-run_pacta.R
+++ b/tests/testthat/test-run_pacta.R
@@ -36,7 +36,6 @@ test_that("avoids overwritting output from a prevoius run", {
 
   fs::dir_create(path(results_path(parent)))
   fs::file_create(path(results_path(parent), "some.file"))
-
   expect_error(run_pacta_impl(path(parent, ".env"), NULL), "must be empty")
 })
 
@@ -47,6 +46,5 @@ test_that("without portfolio errors gracefully", {
   local_pacta(parent)
 
   fs::file_delete(path(parent, "input", "TestPortfolio_Input.csv"))
-
   expect_snapshot_error(run_pacta_impl(path(parent, ".env"), code = NULL))
 })

--- a/tests/testthat/test-run_pacta.R
+++ b/tests/testthat/test-run_pacta.R
@@ -48,3 +48,13 @@ test_that("without portfolio errors gracefully", {
   fs::file_delete(path(parent, "input", "TestPortfolio_Input.csv"))
   expect_snapshot_error(run_pacta_impl(path(parent, ".env"), code = NULL))
 })
+
+test_that("without a parameter file errors gracefully", {
+  skip_on_ci()
+  skip_on_cran()
+  parent <- path_home("pacta_tmp")
+  local_pacta(parent)
+
+  fs::file_delete(path(parent, "input", "TestPortfolio_Input_PortfolioParameters.yml"))
+  expect_snapshot_error(run_pacta_impl(path(parent, ".env"), code = NULL))
+})

--- a/tests/testthat/test-run_pacta.R
+++ b/tests/testthat/test-run_pacta.R
@@ -40,16 +40,13 @@ test_that("avoids overwritting output from a prevoius run", {
   expect_error(run_pacta_impl(path(parent, ".env"), NULL), "must be empty")
 })
 
-test_that("if input/ lacks portfolio and parameter files throws a warning", {
+test_that("without portfolio errors gracefully", {
   skip_on_ci()
   skip_on_cran()
   parent <- path_home("pacta_tmp")
   local_pacta(parent)
 
-  # Remove required files
   fs::file_delete(path(parent, "input", "TestPortfolio_Input.csv"))
-  fs::file_delete(path(parent, "input", "TestPortfolio_Input_PortfolioParameters.yml"))
-  expect_warning(
-    run_pacta_impl(path(parent, ".env"), code = NULL)
-  )
+
+  expect_snapshot_error(run_pacta_impl(path(parent, ".env"), code = NULL))
 })

--- a/tests/testthat/test-run_pacta.R
+++ b/tests/testthat/test-run_pacta.R
@@ -17,14 +17,25 @@ test_that("creates the expected results", {
   expect_snapshot(datasets)
 })
 
+test_that("doesn't fail if output exists but is empty", {
+  skip_on_ci()
+  skip_on_cran()
+  parent <- path_home("pacta_tmp")
+  local_pacta(parent)
+
+  dir_create(results_path(parent))
+
+  expect_no_error(run_pacta_impl(path(parent, ".env"), code = NULL))
+})
+
 test_that("avoids overwritting output from a prevoius run", {
   skip_on_ci()
   skip_on_cran()
   parent <- path_home("pacta_tmp")
   local_pacta(parent)
 
-  # Pretend we have previous results
-  dir_create(results_path(parent))
+  fs::dir_create(path(results_path(parent)))
+  fs::file_create(path(results_path(parent), "some.file"))
 
-  expect_snapshot_error(run_pacta(path(parent, ".env")))
+  expect_error(run_pacta_impl(path(parent, ".env"), NULL), "must be empty")
 })

--- a/tests/testthat/test-run_pacta.R
+++ b/tests/testthat/test-run_pacta.R
@@ -55,6 +55,7 @@ test_that("without a parameter file errors gracefully", {
   parent <- path_home("pacta_tmp")
   local_pacta(parent)
 
-  fs::file_delete(path(parent, "input", "TestPortfolio_Input_PortfolioParameters.yml"))
+  param <- path(parent, "input", "TestPortfolio_Input_PortfolioParameters.yml")
+  fs::file_delete(param)
   expect_snapshot_error(run_pacta_impl(path(parent, ".env"), code = NULL))
 })

--- a/tests/testthat/test-run_pacta.R
+++ b/tests/testthat/test-run_pacta.R
@@ -39,3 +39,17 @@ test_that("avoids overwritting output from a prevoius run", {
 
   expect_error(run_pacta_impl(path(parent, ".env"), NULL), "must be empty")
 })
+
+test_that("if input/ lacks portfolio and parameter files throws a warning", {
+  skip_on_ci()
+  skip_on_cran()
+  parent <- path_home("pacta_tmp")
+  local_pacta(parent)
+
+  # Remove required files
+  fs::file_delete(path(parent, "input", "TestPortfolio_Input.csv"))
+  fs::file_delete(path(parent, "input", "TestPortfolio_Input_PortfolioParameters.yml"))
+  expect_warning(
+    run_pacta_impl(path(parent, ".env"), code = NULL)
+  )
+})


### PR DESCRIPTION
This PR follows a bug reported by @jdhoffa where `run_pacta()` failed for unclear reasons -- apparently related to the output/ directory, but actually due to missing inputs.

As I explore the issue this PR ended up doing more than one thing (let me know if you prefer me to split it and resubmit):

1. Fail fast if required inputs are missing, and allow existing but empty output working_dir/: See tests.

2. Make it easier to test `run_pacta()`

This PR helps by making `run_pacta()` a thin wrapper around the new internal `run_pacta_impl()`.  `run_pacta_impl()` exposes the `code` argument which defaults to call `system(docker_run)` but can be modified to avoid such a time consuming final step and instead test for the state of the function before it. This is a developer-facing function and aims not to have a pretty interface.

Examples:

``` r
devtools::load_all()
#> ℹ Loading pactaCore
parent <- path_home("pacta_tmp")
create_pacta(parent)
env <- path(parent, ".env")

# Do nothing
run_pacta_impl(env, code = NULL)

# Which is the working directory?
run_pacta_impl(env, code = expression(print(getwd())))
#> [1] "/home/mauro/git/pactaCore/inst/extdata/context"

# Where do we write results
run_pacta_impl(env, code = expression(print(results_path(fs::path_dir(output)))))
#> /home/mauro/pacta_tmp/output/working_dir/40_Results/TestPortfolio_Input

fs::dir_delete(parent)
```
