### PR TITLE
Improve aborts with bad IO

### DIFF
--- a/R/run_pacta.R
+++ b/R/run_pacta.R
@@ -35,7 +35,8 @@ run_pacta_impl <- function(env = ".env",
                            code = expression(system(docker_run))) {
   input <- path_env("PACTA_INPUT", env)
   output <- path_env("PACTA_OUTPUT", env)
-  abort_if_dir_exists(results_path(fs::path_dir(output)))
+  abort_if_missing_inputs(input)
+  abort_if_not_empty_dir(results_path(path_dir(output)))
 
   data <- path_env("PACTA_DATA", env)
   # r"()" was introduced in R 4.0.0

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,14 +27,6 @@ create_working_dir <- function(dir = tempdir()) {
   invisible(dir)
 }
 
-abort_if_dir_exists <- function(dir) {
-  if (dir_exists(dir)) {
-    stop("This directory must not exist but it does:\n", dir, call. = FALSE)
-  }
-
-  invisible(dir)
-}
-
 portfolio_names <- function(dir, regexp) {
   csv <- fs::dir_ls(dir, regexp = regexp)
   fs::path_ext_remove(fs::path_file(csv))
@@ -177,4 +169,41 @@ update_pacta_legacy <- function(file = context_path("pacta_legacy.R")) {
   writeLines(code, file)
 
   invisible(file)
+}
+
+abort_if_not_empty_dir <- function(path) {
+  if (dir_exists(path) && !is_empty_dir(path)) {
+    stop(
+      "This directory must be empty but isn't:\n",
+      path,
+      call. = FALSE
+    )
+  }
+  invisible(path)
+}
+
+is_empty_dir <- function(path) {
+  identical(unname(unclass(dir_ls(path))), character(0))
+}
+
+expect_no_error <- function(object, ...) {
+  testthat::expect_error(object, regexp = NA, ...)
+}
+
+abort_if_missing_inputs <- function(path) {
+  portfolio <- dir_ls(path, regexp = "Input[.]csv")
+  parameter <- dir_ls(path, regexp = "Input_PortfolioParameters[.]yml")
+  missing_portfolio <- identical(unclass(unname(portfolio)), character(0))
+  missing_parameter <- identical(unclass(unname(parameter)), character(0))
+  if (missing_portfolio || missing_parameter) {
+    stop(
+      "The input/ directory must have at least one pair of files:\n",
+      "* A porfolio file named <pair-name>_Input.csv.\n",
+      "* A parameter file named <pair-name>_Input_PortfolioParameters.yml.\n",
+      "Is your setup as per https://github.com/2DegreesInvesting/pactaCore?",
+      call. = FALSE
+    )
+  }
+
+  invisible(path)
 }

--- a/tests/testthat/test-run_pacta.R
+++ b/tests/testthat/test-run_pacta.R
@@ -17,14 +17,45 @@ test_that("creates the expected results", {
   expect_snapshot(datasets)
 })
 
+test_that("doesn't fail if output exists but is empty", {
+  skip_on_ci()
+  skip_on_cran()
+  parent <- path_home("pacta_tmp")
+  local_pacta(parent)
+
+  dir_create(results_path(parent))
+
+  expect_no_error(run_pacta_impl(path(parent, ".env"), code = NULL))
+})
+
 test_that("avoids overwritting output from a prevoius run", {
   skip_on_ci()
   skip_on_cran()
   parent <- path_home("pacta_tmp")
   local_pacta(parent)
 
-  # Pretend we have previous results
-  dir_create(results_path(parent))
+  fs::dir_create(path(results_path(parent)))
+  fs::file_create(path(results_path(parent), "some.file"))
+  expect_error(run_pacta_impl(path(parent, ".env"), NULL), "must be empty")
+})
 
-  expect_snapshot_error(run_pacta(path(parent, ".env")))
+test_that("without portfolio errors gracefully", {
+  skip_on_ci()
+  skip_on_cran()
+  parent <- path_home("pacta_tmp")
+  local_pacta(parent)
+
+  fs::file_delete(path(parent, "input", "TestPortfolio_Input.csv"))
+  expect_snapshot_error(run_pacta_impl(path(parent, ".env"), code = NULL))
+})
+
+test_that("without a parameter file errors gracefully", {
+  skip_on_ci()
+  skip_on_cran()
+  parent <- path_home("pacta_tmp")
+  local_pacta(parent)
+
+  param <- path(parent, "input", "TestPortfolio_Input_PortfolioParameters.yml")
+  fs::file_delete(param)
+  expect_snapshot_error(run_pacta_impl(path(parent, ".env"), code = NULL))
 })


### PR DESCRIPTION
Splits off #64

- Fail fast if input/ lacks portfolio and parameter files.

- Allow empty results directory (workding_dir/).
