### PR TITLE
Ignore all _snaps to avoid leaking private data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Renviron
 README_cache/
 cache
+tests/testthat/_snaps


### PR DESCRIPTION
This may be too hard core. I may follow up with a more granular approach
where we allow specific public snapshots.﻿

This PR adds the general pattern to ignore so we default for security and private data doesn't leak unintentionally. Safe snapshots should be added via a negating pattern, e.g.:

```
# .gitignore
tests/testthat/_snaps
!tests/testthat/_snaps/a-public-snapshot.md
```