### PR TITLE
Don't ignore public snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,7 @@
 .Renviron
 README_cache/
 cache
-tests/testthat/_snaps
+
+# Ignore private snapshots with suffix "_private". For example:
+# Create a private snapshot of `f()` in test-f_private.R
+tests/testthat/_snaps/*_private.md

--- a/tests/testthat/_snaps/run_pacta.md
+++ b/tests/testthat/_snaps/run_pacta.md
@@ -1,0 +1,14 @@
+# without portfolio errors gracefully
+
+    The input/ directory must have at least one pair of files:
+    * A porfolio file named <pair-name>_Input.csv.
+    * A parameter file named <pair-name>_Input_PortfolioParameters.yml.
+    Is your setup as per https://github.com/2DegreesInvesting/pactaCore?
+
+# without a parameter file errors gracefully
+
+    The input/ directory must have at least one pair of files:
+    * A porfolio file named <pair-name>_Input.csv.
+    * A parameter file named <pair-name>_Input_PortfolioParameters.yml.
+    Is your setup as per https://github.com/2DegreesInvesting/pactaCore?
+

--- a/tests/testthat/test-run_pacta.R
+++ b/tests/testthat/test-run_pacta.R
@@ -1,22 +1,3 @@
-test_that("creates the expected results", {
-  skip_on_ci()
-  skip_on_cran()
-  skip_slow_tests()
-  parent <- path_home("pacta_tmp")
-  local_pacta(parent)
-
-  run_pacta(path(parent, ".env"))
-  files <- dir_ls(results_path(parent), type = "file", recurse = TRUE)
-  datasets <- lapply(files, readRDS)
-  names(datasets) <- path_ext_remove(path_file(names(datasets)))
-
-  classes <- lapply(datasets, function(x) unlist(lapply(x, class)))
-  expect_snapshot(classes)
-
-  datasets[] <- lapply(datasets, as.data.frame)
-  expect_snapshot(datasets)
-})
-
 test_that("doesn't fail if output exists but is empty", {
   skip_on_ci()
   skip_on_cran()

--- a/tests/testthat/test-run_pacta_private.R
+++ b/tests/testthat/test-run_pacta_private.R
@@ -1,0 +1,18 @@
+test_that("creates the expected results", {
+  skip_on_ci()
+  skip_on_cran()
+  skip_slow_tests()
+  parent <- path_home("pacta_tmp")
+  local_pacta(parent)
+
+  run_pacta(path(parent, ".env"))
+  files <- dir_ls(results_path(parent), type = "file", recurse = TRUE)
+  datasets <- lapply(files, readRDS)
+  names(datasets) <- path_ext_remove(path_file(names(datasets)))
+
+  classes <- lapply(datasets, function(x) unlist(lapply(x, class)))
+  expect_snapshot(classes)
+
+  datasets[] <- lapply(datasets, as.data.frame)
+  expect_snapshot(datasets)
+})


### PR DESCRIPTION
This PR ignores snaphsots ending with "_private". For example, snapshots produced in a file named test-fun_private.R will be ignored. 

Unfortunately this approach doesn't allow sharing snapshots among developers, thus
limiting their ability to reproduce failing regression tests except in your own computer.

See also #69