### PR TITLE
ignore snapshots except if eplicitely re included

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,11 @@
 .Renviron
 README_cache/
 cache
-tests/testthat/_snaps
+
+# Ignore all snapshots. From https://git-scm.com/docs/gitignore:
+# > It is not possible to re-include a file if a parent directory of
+# > that file is excluded ... "/**" matches everything inside.
+tests/testthat/_snaps/**
+
+# Re-include safe snapshots
+!tests/testthat/_snaps/run_pacta.md

--- a/tests/testthat/_snaps/run_pacta.md
+++ b/tests/testthat/_snaps/run_pacta.md
@@ -1,0 +1,14 @@
+# without portfolio errors gracefully
+
+    The input/ directory must have at least one pair of files:
+    * A porfolio file named <pair-name>_Input.csv.
+    * A parameter file named <pair-name>_Input_PortfolioParameters.yml.
+    Is your setup as per https://github.com/2DegreesInvesting/pactaCore?
+
+# without a parameter file errors gracefully
+
+    The input/ directory must have at least one pair of files:
+    * A porfolio file named <pair-name>_Input.csv.
+    * A parameter file named <pair-name>_Input_PortfolioParameters.yml.
+    Is your setup as per https://github.com/2DegreesInvesting/pactaCore?
+

--- a/tests/testthat/test-run_pacta.R
+++ b/tests/testthat/test-run_pacta.R
@@ -1,22 +1,3 @@
-test_that("creates the expected results", {
-  skip_on_ci()
-  skip_on_cran()
-  skip_slow_tests()
-  parent <- path_home("pacta_tmp")
-  local_pacta(parent)
-
-  run_pacta(path(parent, ".env"))
-  files <- dir_ls(results_path(parent), type = "file", recurse = TRUE)
-  datasets <- lapply(files, readRDS)
-  names(datasets) <- path_ext_remove(path_file(names(datasets)))
-
-  classes <- lapply(datasets, function(x) unlist(lapply(x, class)))
-  expect_snapshot(classes)
-
-  datasets[] <- lapply(datasets, as.data.frame)
-  expect_snapshot(datasets)
-})
-
 test_that("doesn't fail if output exists but is empty", {
   skip_on_ci()
   skip_on_cran()

--- a/tests/testthat/test-run_pacta_private.R
+++ b/tests/testthat/test-run_pacta_private.R
@@ -1,0 +1,18 @@
+test_that("creates the expected results", {
+  skip_on_ci()
+  skip_on_cran()
+  skip_slow_tests()
+  parent <- path_home("pacta_tmp")
+  local_pacta(parent)
+
+  run_pacta(path(parent, ".env"))
+  files <- dir_ls(results_path(parent), type = "file", recurse = TRUE)
+  datasets <- lapply(files, readRDS)
+  names(datasets) <- path_ext_remove(path_file(names(datasets)))
+
+  classes <- lapply(datasets, function(x) unlist(lapply(x, class)))
+  expect_snapshot(classes)
+
+  datasets[] <- lapply(datasets, as.data.frame)
+  expect_snapshot(datasets)
+})


### PR DESCRIPTION
- Ignore all snapshots except public ones
- Separate public from private snapshots, so the public ones can be shared
