### PR TITLE
Use image 2dii/r-packages for consistency

### DIFF
--- a/inst/extdata/context/Dockerfile
+++ b/inst/extdata/context/Dockerfile
@@ -1,8 +1,2 @@
-FROM rocker/r-ver:latest
-
-RUN Rscript -e 'install.packages("remotes")'
-
-COPY DESCRIPTION /bound/DESCRIPTION
-RUN Rscript -e 'remotes::install_deps("/bound", dependencies = TRUE)'
-
+FROM 2dii/r-packages
 COPY . /bound


### PR DESCRIPTION
This PR reuses the image 2dii/r-packages. This is
motivated by a bug in the previous image related
to the lack of some required packages. Debugging
that was hard because the docker image lacks 
RStudio and thus its helpful interactive debugger.

I did not get to the bottom of the problem because
using the image 2dii/r-packages solved the problem
and seems a good fit for my next task: to snapshot
results of the web tool.


